### PR TITLE
add a release manually by providing a release id

### DIFF
--- a/app/controllers/admin/discogs/releases_controller.rb
+++ b/app/controllers/admin/discogs/releases_controller.rb
@@ -16,6 +16,6 @@ class Admin::Discogs::ReleasesController < Admin::BaseController
   private
 
   def admin_discogs_release_params
-    params.require(:admin_discogs_release).permit(:discogs_release_id)
+    params.require(:admin_discogs_release).permit(:discogs_release_id, :manual_discogs_release_id)
   end
 end

--- a/app/forms/admin/discogs/release_form.rb
+++ b/app/forms/admin/discogs/release_form.rb
@@ -9,7 +9,7 @@ class Admin::Discogs::ReleaseForm < ApplicationForm
     @object = object
     @params = params
 
-    @discogs_release_id = params[:discogs_release_id]
+    @discogs_release_id = params[:discogs_release_id].presence || params[:manual_discogs_release_id].presence
   end
 
   def missing_label_releases

--- a/app/views/admin/discogs/releases/new.html.haml
+++ b/app/views/admin/discogs/releases/new.html.haml
@@ -3,9 +3,9 @@
   = link_to 'Back to releases', admin_releases_path, class: 'ml-2 text-gray-500 text-sm'
 
 .rounded-lg.border.border-gray-200.shadow-xl.bg-white.p-8
-  .my-4
-    - if @form.missing_label_releases_options.any?
-      = form_with model: @form do |f|
+  = form_with model: @form do |f|
+    .my-4
+      - if @form.missing_label_releases_options.any?
         .field
           = f.label :discogs_release_id, 'Discogs Release', class: 'block text-sm leading-5 tracking-wide text-gray-600'
           = f.select :discogs_release_id,
@@ -16,7 +16,18 @@
             .text-red-400.text-xs.mt-1
               = @form.errors.messages[:discogs_release_id].join(' and ')
 
-        .actions.mt-6
-          = f.submit 'Fetch Release From Discogs', class: 'button'
-    - else
-      .text-center.text-gray-700 Could not find any releases on Discogs that are not in our database yet.
+      - else
+        .text-gray-700
+          Could not find any releases on Discogs API that are not in our database yet.
+          \
+          You can still add a release manually below.
+
+      .my-4
+        = f.label :manual_discogs_release_id, 'Manual Discogs Release ID', class: 'block text-sm leading-5 tracking-wide text-gray-600'
+        = f.text_field :manual_discogs_release_id,
+                       class: 'py-2 px-2 rounded border sm:text-sm sm:leading-5'
+        .text-gray-500.text-xs Use this field if the release does not appear in the dropdown above, or there is no dropdown.
+
+      .actions.mt-6
+        = f.submit 'Fetch Release From Discogs', class: 'button'
+

--- a/test/controllers/admin/discogs/releases_controller_test.rb
+++ b/test/controllers/admin/discogs/releases_controller_test.rb
@@ -8,6 +8,19 @@ class Admin::Discogs::ReleasesControllerTest < ActionDispatch::IntegrationTest
     assert_difference -> { Release.count }, 1 do
       post admin_discogs_releases_path, params: { admin_discogs_release: { discogs_release_id: 5835903 } }
     end
+
+    follow_redirect!
+    assert_response :success
+  end
+
+  test '#create with manual release id' do
+    discogs_release_stub(5835903)
+    sign_in
+
+    assert_difference -> { Release.count }, 1 do
+      post admin_discogs_releases_path, params: { admin_discogs_release: { manual_discogs_release_id: 5835903 } }
+    end
+
     follow_redirect!
     assert_response :success
   end

--- a/test/fixtures/files/responses/discogs/label_827644_no_new_release.json
+++ b/test/fixtures/files/responses/discogs/label_827644_no_new_release.json
@@ -1,0 +1,31 @@
+{
+  "pagination": {
+    "per_page": 10,
+    "items": 1,
+    "page": 1,
+    "pages": 1
+  },
+  "releases": [
+    {
+      "status": "Accepted",
+      "artist": "Home Street Home",
+      "catno": "HSH001",
+      "thumb": "https://img.discogs.com/RxN04JCQ979SZrcqfd35X9lIBzc=/fit-in/150x150/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-5303073-1390056310-2222.jpeg.jpg",
+      "format": "CD, Comp + 20xFile, MP3, 192",
+      "stats": {
+        "user": {
+          "in_collection": 0,
+          "in_wantlist": 0
+        },
+        "community": {
+          "in_collection": 1,
+          "in_wantlist": 0
+        }
+      },
+      "resource_url": "https://api.discogs.com/releases/5303073",
+      "title": "Bustin' Through The Ceiling",
+      "year": 2014,
+      "id": 5303073
+    }
+  ]
+}

--- a/test/stubs/discogs.rb
+++ b/test/stubs/discogs.rb
@@ -1,10 +1,15 @@
 require 'stubs/discogs/base_stub'
 require 'stubs/discogs/label_releases_stub'
 require 'stubs/discogs/label_releases_1_to_3_stub'
+require 'stubs/discogs/label_no_new_release_stub'
 require 'stubs/discogs/release_stub'
 require 'stubs/discogs/release_not_found_stub'
 
 module DiscogsStubs
+  def discogs_label_no_new_release_stub
+    to_stub(Discogs::LabelNoNewReleaseStub.new.stub_struct)
+  end
+
   def discogs_label_releases_stubs
     to_stub(Discogs::LabelReleasesStub.new(page: 1).stub_struct)
     to_stub(Discogs::LabelReleasesStub.new(page: 2).stub_struct)

--- a/test/stubs/discogs/label_no_new_release_stub.rb
+++ b/test/stubs/discogs/label_no_new_release_stub.rb
@@ -1,0 +1,22 @@
+module Discogs
+  class LabelNoNewReleaseStub < BaseStub
+    def initialize
+      @label_id = Rails.configuration.discogs[:home_street_home_label_id]
+    end
+
+    def url
+      [
+        'https://api.discogs.com/labels/',
+        @label_id,
+        '/releases?f=json',
+        '&page=1&per_page=10',
+        '&token=',
+        Rails.configuration.discogs[:api_token]
+      ].join
+    end
+
+    def response_fixture_file_path
+      "responses/discogs/label_#{@label_id}_no_new_release.json"
+    end
+  end
+end

--- a/test/system/admin/releases_test.rb
+++ b/test/system/admin/releases_test.rb
@@ -35,6 +35,29 @@ class Admin::ReleasesTest < ApplicationSystemTestCase
     click_on 'Back'
   end
 
+  test 'creating a Release by providing the release id manually' do
+    discogs_label_releases_stubs
+    discogs_release_stub(5835903)
+
+    sign_in
+    click_on 'Fetch Release From Discogs'
+
+    fill_in 'Manual Discogs Release ID', with: '5835903'
+    click_on 'Fetch Release From Discogs'
+
+    assert_text 'Release was successfully created'
+    click_on 'Back'
+  end
+
+  test 'displays manual discogs release id input field, even if API returns none' do
+    discogs_label_no_new_release_stub
+    sign_in
+    click_on 'Fetch Release From Discogs'
+
+    assert has_field? 'Manual Discogs Release ID', type: 'text'
+    assert_not has_field? 'Discogs Release', type: 'text', exact: true
+  end
+
   test 'updating a Release' do
     sign_in
     visit admin_releases_url


### PR DESCRIPTION
A newly submitted release did not show up on the "All Label Releases" endpoint of the Discogs API.
However, the release can be fetched through the "Releases" endpoint. 
This Commit enables us to add a release by providing a Discogs Release ID manually.